### PR TITLE
Add payload encryption

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -5,6 +5,7 @@
 # as the module Kconfig entry point (see zephyr/module.yml). You can browse
 # module options by going to Zephyr -> Modules in Kconfig.
 
+rsource "app/Kconfig.payload_enc"
 rsource "drivers/Kconfig"
 rsource "subsys/bluetooth/services/Kconfig.nus"
 rsource "subsys/shell/modules/Kconfig"

--- a/PAYLOAD-ENCRYPTION.md
+++ b/PAYLOAD-ENCRYPTION.md
@@ -1,0 +1,50 @@
+# Optional payload encryption
+
+If a symmetric key is configured from the Zephyr shell, and the feature is
+enabled during build, then payload is sent encrypted with an AES128 key over
+LoRaWan. Payload will not be readable in the Helium console. Only your
+private Helium integration server would have the AES key, and thus be able
+to decrypt the payload data.
+
+Note that the LoRaWan metadata (e.g. which hotspot relayed a packet) would
+not be protected by that AES128 key. The latter is only for the payload.
+
+## Adding support to the firmware
+
+Simply enable the PAYLOAD_ENCRYPTION config. Example:
+```
+west build --pristine  -b rak4631_nrf52840 -s app -- -DCONFIG_USB_DFU_REBOOT=y -DCONFIG_BT=n -DCONFIG_PAYLOAD_ENCRYPTION=y
+```
+
+## Enabling encryption
+
+First create an AES key:
+```
+$ openssl rand -hex 16 | tee payload_aes_key.hex
+```
+Then save it to the device using the Zephyr shell, e.g.:
+```
+uart:~$ lorawan payload_key f4d1cbcae025b1ab6fa124f99e1f21d3
+```
+
+To erase the key, and thus fallback to sending payload in clear, simply
+write all-zeros as a key:
+```
+uart:~$ lorawan payload_key 00000000000000000000000000000000
+```
+
+## Decrypting
+
+Here is an example Python snippet to decrypt the payload on your Helium integration server:
+```
+import base64
+import binascii
+from Crypto.Cipher import AES
+
+payload_enc = base64.b64decode(payload_base64_str)
+with open('payload_aes_key.hex') as f:
+    key = binascii.unhexlify(f.readline().strip())
+iv = payload_enc[:16]
+cipher = AES.new(key, AES.MODE_CBC, iv)
+payload_clear = cipher.decrypt(payload_enc[16:])
+```

--- a/README.md
+++ b/README.md
@@ -380,3 +380,7 @@ secondary area (2):
 ```
 
 Note! In case new image not confirmed, or fails to boot, it will automatically revert to last working image into slot-0
+
+### Payload Encryption
+
+The optional payload encryption support is documented [here](./PAYLOAD-ENCRYPTION.md).

--- a/app/Kconfig.payload_enc
+++ b/app/Kconfig.payload_enc
@@ -1,0 +1,14 @@
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+config PAYLOAD_ENCRYPTION
+	bool "Payload encryption support"
+	select TINYCRYPT
+	select TINYCRYPT_AES
+	select TINYCRYPT_AES_CBC
+	select TINYCRYPT_CTR_PRNG
+	select ENTROPY
+	select ENTROPY_GENERATOR
+	help
+	  Build with support for symmetric encryption of the LoraWan payload.

--- a/app/src/lorawan_config.h
+++ b/app/src/lorawan_config.h
@@ -44,6 +44,10 @@ struct s_lorawan_config
 	uint32_t max_inactive_time_window;
 	/* Number of failed message before re-join */
 	uint32_t max_failed_msg;
+#if IS_ENABLED(CONFIG_PAYLOAD_ENCRYPTION)
+	/* AES128 key for encrypting the payload. */
+	uint8_t payload_key[128/8];
+#endif
 };
 
 extern struct s_lorawan_config lorawan_config;

--- a/app/src/nvm.c
+++ b/app/src/nvm.c
@@ -35,6 +35,9 @@ static const struct hm_nvm_setting_descr hm_nvm_setting_descriptors[] = {
 	HM_NVM_SETTING_DESCR(send_repeat_time),
 	HM_NVM_SETTING_DESCR(send_min_delay),
 	HM_NVM_SETTING_DESCR(max_gps_on_time),
+#if IS_ENABLED(CONFIG_PAYLOAD_ENCRYPTION)
+	HM_NVM_SETTING_DESCR(payload_key),
+#endif
 };
 
 void hm_lorawan_nvm_save_settings(const char *name)


### PR DESCRIPTION
This patch adds optional payload encryption support.

Tested with the following build config:
```
west build --pristine  -b rak4631_nrf52840 -s app -- -DCONFIG_USB_DFU_REBOOT=y -DCONFIG_BT=n -DCONFIG_PAYLOAD_ENCRYPTION=y
dfu-util --alt 1 -d 2fe9:0100 --download build/zephyr/zephyr.signed.bin
```
Signed-off-by: Dimitar Dimitrov <dimitar@dinux.eu>