### PR TITLE
Initialize timers before starting the LoRa thread

### DIFF
--- a/app/src/main.c
+++ b/app/src/main.c
@@ -1009,6 +1009,8 @@ void main(void)
 	}
 #endif
 
+	init_timers(ctx);
+
 	ret = init_lora(ctx);
 	if (ret) {
 		LOG_ERR("Rebooting in 30 sec.");
@@ -1017,7 +1019,6 @@ void main(void)
 		return;
 	}
 
-	init_timers(ctx);
 
 	while (true) {
 		LOG_INF("Waiting for events...");


### PR DESCRIPTION
When the first LoRa join request failed, the device was left frozen with a turned green LED. Even the USB shell was not responsive (no echo characters seen, no commands executed).

The LoRa thread for handling JOINs is using a timer. But the timers were initialized _after_ that thread was run.